### PR TITLE
Tagupdates

### DIFF
--- a/edges.lua
+++ b/edges.lua
@@ -524,7 +524,8 @@ function filter_tags_generic(kv)
   kv["emergency_forward"] = "false"
   kv["emergency_backward"] = "false"
 
-  if kv["access"] == "emergency" or kv["emergency"] == "yes" or kv["service"] == "emergency_access" then
+  if (ferry == true or kv["highway"]) and 
+     (kv["access"] == "emergency" or kv["emergency"] == "yes" or kv["service"] == "emergency_access") then
     kv["emergency_forward"] = "true"
   end
 
@@ -768,6 +769,11 @@ function filter_tags_generic(kv)
      kv["pedestrian"] == "false" then
     return 1
   end
+
+   --toss areas
+   if kv["area"] then
+     return 1
+   end
 
    delete_tags = { 'FIXME', 'note', 'source' }
 

--- a/valhalla.json
+++ b/valhalla.json
@@ -185,9 +185,9 @@
     "multimodal": {
     },
     "transit": {
-      "use_bus": 0.5,
+      "use_bus": 0.3,
       "use_rail": 0.5,
-      "use_transfers": 0.5
+      "use_transfers": 1.0
     }
   }
 }

--- a/valhalla.json
+++ b/valhalla.json
@@ -196,7 +196,9 @@
     "transit": {
       "use_bus": 0.3,
       "use_rail": 0.5,
-      "use_transfers": 1.0
+      "use_transfers": 1.0,
+      "transfer_cost": 60.0,
+      "transfer_penalty": 300.0
     }
   }
 }

--- a/valhalla.json
+++ b/valhalla.json
@@ -163,7 +163,16 @@
       "length": 21.64,
       "weight": 36.29,
       "axle_load": 9.07,
-      "hazmat": false
+      "hazmat": false,
+      "low_class_penalty": 30.0,
+      "maneuver_penalty": 5.0,
+      "destination_only_penalty": 600.0,
+      "alley_penalty": 5.0,
+      "gate_cost": 30.0,
+      "toll_booth_cost": 15.0,
+      "toll_booth_penalty": 0.0,
+      "country_crossing_cost": 600.0,
+      "country_crossing_penalty": 0.0
     },
     "pedestrian": {
       "walking_speed": 5.1,

--- a/valhalla.json
+++ b/valhalla.json
@@ -153,6 +153,14 @@
     },
     "bus": {
     },
+    "truck": {
+      "height": 4.11,
+      "width": 2.6,
+      "length": 15.24,
+      "weight": 36.29,
+      "axle_load": 9.07,
+      "hazmat": false
+    },
     "pedestrian": {
       "walking_speed": 5.1,
       "walkway_factor": 0.9,
@@ -173,6 +181,9 @@
     "multimodal": {
     },
     "transit": {
+      "use_bus": 0.5,
+      "use_rail": 0.5,
+      "use_transfers": 0.5
     }
   }
 }

--- a/valhalla.json
+++ b/valhalla.json
@@ -156,7 +156,7 @@
     "truck": {
       "height": 4.11,
       "width": 2.6,
-      "length": 15.24,
+      "length": 21.64,
       "weight": 36.29,
       "axle_load": 9.07,
       "hazmat": false

--- a/valhalla.json
+++ b/valhalla.json
@@ -161,7 +161,7 @@
       "height": 4.11,
       "width": 2.6,
       "length": 21.64,
-      "weight": 36.29,
+      "weight": 21.77,
       "axle_load": 9.07,
       "hazmat": false,
       "low_class_penalty": 30.0,


### PR DESCRIPTION
added truck defaults and transit use_*
toss areas and emergency areas with no highway or ferry tag.