### PR TITLE
Kd logging updates

### DIFF
--- a/valhalla.json
+++ b/valhalla.json
@@ -43,7 +43,8 @@
     "actions":["locate","route","one_to_many","many_to_one","many_to_many"],
     "logging": {
       "type": "std_out",
-      "color": true
+      "color": true,
+      "long_request": 100.0
     },
     "service": {
       "proxy": "ipc:///tmp/loki"

--- a/valhalla.json
+++ b/valhalla.json
@@ -84,7 +84,7 @@
     "logging": {
       "type": "std_out",
       "color": true,
-      "long_request": 10.0
+      "long_request": 100.0
     },
     "service": {
       "proxy": "ipc:///tmp/tyr"

--- a/valhalla.json
+++ b/valhalla.json
@@ -53,7 +53,8 @@
     "actions":["height"],
     "logging": {
       "type": "std_out",
-      "color": true
+      "color": true,
+      "long_request": 5.0
     },
     "service": {
       "proxy": "ipc:///tmp/skadi"
@@ -62,7 +63,8 @@
   "thor": {
     "logging": {
       "type": "std_out",
-      "color": true
+      "color": true,
+      "long_request": 110.0
     },
     "service": {
       "proxy": "ipc:///tmp/thor"
@@ -80,7 +82,8 @@
   "tyr": {
     "logging": {
       "type": "std_out",
-      "color": true
+      "color": true,
+      "long_request": 10.0
     },
     "service": {
       "proxy": "ipc:///tmp/tyr"


### PR DESCRIPTION
added a long_request threshold (ms) to trigger a log warning, request and count in logstash
I'm not sure what the tyr long_request shoud be for route and multimodal route requests.  Any suggestions??