### PR TITLE
Add meili config

### DIFF
--- a/valhalla.json
+++ b/valhalla.json
@@ -55,6 +55,50 @@
       "proxy": "ipc:///tmp/odin"
     }
   },
+  "meili": {
+    "mode": "multimodal",
+    "customizable": ["mode", "search_radius"],
+    "verbose": false,
+    "default": {
+      "sigma_z": 4.07,
+      "beta": 3,
+      "max_route_distance_factor": 3,
+      "breakage_distance": 2000,
+      "interpolation_distance": 10,
+      "search_radius": 40,
+      "max_search_radius": 100,
+      "geometry": false,
+      "route": true,
+      "turn_penalty_factor": 0
+    },
+    "auto": {
+      "turn_penalty_factor": 200,
+      "search_radius": 50
+    },
+    "pedestrian": {
+      "turn_penalty_factor": 100,
+      "search_radius": 25
+    },
+    "bicycle": {
+      "turn_penalty_factor": 140
+    },
+    "multimodal": {
+      "turn_penalty_factor": 70
+    },
+    "logging": {
+      "type": "std_out",
+      "color": true
+    },
+    "service": {
+      "proxy": "ipc:///tmp/meili",
+      "listen": "tcp://*:8001",
+      "loopback": "ipc:///tmp/meili_loopback"
+    }
+  },
+  "grid": {
+    "size": 500,
+    "cache_size": 64
+  },
   "tyr": {
     "logging": {
       "type": "std_out",

--- a/valhalla.json
+++ b/valhalla.json
@@ -90,9 +90,7 @@
       "color": true
     },
     "service": {
-      "proxy": "ipc:///tmp/meili",
-      "listen": "tcp://*:8001",
-      "loopback": "ipc:///tmp/meili_loopback"
+      "proxy": "ipc:///tmp/meili"
     }
   },
   "grid": {


### PR DESCRIPTION
Meili uses a separate conf but it also reads valhalla/conf to get tiles. Would be great they can merge.

Two required nodes were added: `meili` and `grid`