### PR TITLE
Add gps_accuracy to https://github.com/valhalla/meili/pull/17

### DIFF
--- a/valhalla.json
+++ b/valhalla.json
@@ -62,6 +62,7 @@
     "verbose": false,
     "default": {
       "sigma_z": 4.07,
+      "gps_accuracy": 4.07,
       "beta": 3,
       "max_route_distance_factor": 3,
       "breakage_distance": 2000,


### PR DESCRIPTION
In the latest PR it requires this parameter to be in the conf.

Also `sigma_z` is same as `gps_accuracy`. I will remove it as soon as Meili gets ready.