### PR TITLE
Increase meili grid cache size since we now index bins 

### DIFF
--- a/valhalla.json
+++ b/valhalla.json
@@ -96,7 +96,7 @@
     },
     "grid": {
       "size": 500,
-      "cache_size": 10240
+      "cache_size": 100240
     }
   },
   "tyr": {


### PR DESCRIPTION
Indexing bins rather than tiles, so we should increase the grid cache size. Increase by 10x. Even though bins are 1/25 of a tile lets start with a lower number for hosted systems.